### PR TITLE
fix inspector for newer WPEWebKit & WPELauncher combination

### DIFF
--- a/board/toldotechnik_rpi/post-build.sh
+++ b/board/toldotechnik_rpi/post-build.sh
@@ -7,3 +7,8 @@ echo "Post-build: processing $@"
 env
 
 BOARD_DIR="$(dirname $0)"
+
+# Newer WPEWebKit requires WEBKIT_LEGACY_INSPECTOR_SERVER for the inspector to work correctly when using WPELauncher
+if [ -e "${TARGET_DIR}/usr/bin/wpe" ]; then
+	sed -i 's/WEBKIT_INSPECTOR_SERVER/WEBKIT_LEGACY_INSPECTOR_SERVER/' "${TARGET_DIR}/usr/bin/wpe"
+fi


### PR DESCRIPTION
The patch that ports WPELauncher from the old (stable) branch creates a `/usr/bin/wpe` script with the environment variable for enabling the remote inspector that only works with the older WPEWebKit.
https://github.com/TOLDOTECHNIK/buildroot-webkit/blob/cb30ee6b840c5be21da9d7ac1fd8b1ec09c831c2/0001-port-wpelauncher-from-stable.patch#L145

The new WPEWebKit with WPELauncher works only if this env var is named `WEBKIT_LEGACY_INSPECTOR_SERVER`.

See https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/549#issuecomment-440960712